### PR TITLE
Add missing config for Replicate UI (a base module)

### DIFF
--- a/config/install/replicate_ui.settings.yml
+++ b/config/install/replicate_ui.settings.yml
@@ -1,0 +1,2 @@
+entity_types:
+  - node


### PR DESCRIPTION
I keep finding base Voyager contrib modules that are either not enabled or are missing config :( 

I think we'll need a story at some point for me to review all the base modules.

For now, here's some missing config I noticed for the Replicate UI module.